### PR TITLE
Fix #3.

### DIFF
--- a/lib/OSX/smc.cc
+++ b/lib/OSX/smc.cc
@@ -185,6 +185,7 @@ double SMCGet(UInt32Char_t key) {
 
 void Get(const FunctionCallbackInfo<Value>& args) {
     Isolate* isolate = Isolate::GetCurrent();
+    Local<Context> context = isolate->GetCurrentContext();
     HandleScope scope(isolate);
     SMCOpen();
     if (args.Length() < 1) {
@@ -193,17 +194,19 @@ void Get(const FunctionCallbackInfo<Value>& args) {
     }
     if (!args[0]->IsString()) {
         isolate->ThrowException(Exception::TypeError(
-        String::NewFromUtf8(isolate, "Expected string")));
+        String::NewFromUtf8(isolate, "Expected string", NewStringType::kNormal)
+        .ToLocalChecked()));
         return;
     }
-    v8::String::Utf8Value k(args[0]->ToString());
+    v8::String::Utf8Value k(
+        isolate, args[0]->ToString(context).ToLocalChecked());
     char *key = *k;
     double value = SMCGet(key);
     SMCClose();
     args.GetReturnValue().Set(Number::New(isolate, value));
 }
 
-void Init(v8::Handle<Object> exports) {
+void Init(v8::Local<Object> exports) {
     NODE_SET_METHOD(exports, "get", Get);
 }
 


### PR DESCRIPTION
Add compatibility for Node 12 and fix deprecation warnings.

## Pull Request

Fixes #3 

#### Changes proposed:

* [x] Fix
* [ ] Enhancement
* [ ] Remove
* [ ] Update

#### Description (what is this PR about)

Brief explanation of the changes you have made and/or the new content you are contributing.

* Renamed an API that node 12 removes (`v8::Handle` -> `v8::Local`)
* Replaced the usage of some APIs (`ToString()` and `String::NewFromUtf8`) to suppress deprecation warnings.

Build succeeded on my MacBook with `node v12.6.0 / v10.6.0 / v8.16.0` but did not do test runs.

References: [1](https://github.com/bcoin-org/bcrypto/issues/7), [2](https://nodejs.org/api/addons.html)
