### PR TITLE
Apple Silicon support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ console.log(temperature);
 
 ### Latest Activity
 
+- Version 1.0.8: add Apple Silicom M1 support
 - Version 1.0.7: updated documentation
 - Version 1.0.6: reverted license to MIT (thanks to Frank Stock)
 - Version 1.0.5: changed license to GPL

--- a/lib/OSX/smc-read.cc
+++ b/lib/OSX/smc-read.cc
@@ -208,6 +208,10 @@ double ToSMCNumber(uint32_t dataType, const SMCBytes_t buf, uint8_t bufLen) {
 			if (bufLen != 4)
 				return NAN;
 			return ntohl(*((uint32_t*) buf));
+    case DATATYPE_FLT_KEY:
+      if (bufLen != 4)
+				return NAN;
+      return *((float*) buf);
 		default:
 			return ToSMCFloat(dataType, ntohs(*((uint16_t*) buf)));
 	}

--- a/lib/OSX/smc-read.h
+++ b/lib/OSX/smc-read.h
@@ -47,6 +47,8 @@ extern "C" {
 #define DATATYPE_FLAG_KEY 0x666C6167    // "flag"
 #define DATATYPE_HEX_KEY 0x6865785F     // "hex_"
 
+#define DATATYPE_FLT_KEY 0x666C7420     // "flt"
+
 uint32_t stringToKey(const char* str);
 
 void keyToString(uint32_t key, char* str);

--- a/lib/index.js
+++ b/lib/index.js
@@ -48,7 +48,13 @@ function cpuTemperature() {
     };
     let smc = require('../build/Release/smc');
 
-    let cores = ['TC0P', 'TC1C', 'TC2C', 'TC3C', 'TC4C', 'TC5C', 'TC6C', 'TC7C', 'TC8C'];
+    let cores = [];
+    if (process.arch == 'arm64') {
+      cores = ['Tp01', 'Tp05', 'Tp0D', 'Tp0H', 'Tp0L', 'Tp0P', 'Tp0X', 'Tp0b', 'Tp09', 'Tp0T'];
+    } else {
+      cores = ['TC0P', 'TC1C', 'TC2C', 'TC3C', 'TC4C', 'TC5C', 'TC6C', 'TC7C', 'TC8C'];
+    }
+
     let sum = 0;
     let id = 0;
     cores.forEach(function(key) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "osx-temperature-sensor",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "OSX temperature sensor",
   "license": "MIT",
   "main": "./lib/index.js",


### PR DESCRIPTION
## Pull Request

Fixes #10 

#### Changes proposed:

* [x] Fix
* [ ] Enhancement
* [ ] Remove
* [ ] Update

#### Description (what is this PR about)

* Adds cpu temperature SMC keys for Apple Silicon M1 (used if process.arch == 'arm64')
* Adds support for "flt" datatype


